### PR TITLE
USB boot options

### DIFF
--- a/include/depthai-bootloader-shared/Bootloader.hpp
+++ b/include/depthai-bootloader-shared/Bootloader.hpp
@@ -39,8 +39,12 @@ namespace request {
         UpdateFlash() : cmd(UPDATE_FLASH) {}
 
         // Data
-        enum Storage : uint32_t { SBR, BOOTLOADER };
+        enum Storage : uint32_t { SBR, BOOTLOADER, BOOT_HEADER };
+        // TODO make BOOT_HEADER and BOOTLOADER storage not overlap.
+        // Then we could have separate actions to update BOOT_HEADER only.
+        enum BootHeader : uint32_t { CUSTOM_PAYLOAD, USB, /* FLASH_SPI_QUAD, */ };
         Storage storage;
+        BootHeader bootHeader;
         uint32_t totalSize;
         uint32_t numPackets;
     };

--- a/include/depthai-bootloader-shared/Bootloader.hpp
+++ b/include/depthai-bootloader-shared/Bootloader.hpp
@@ -21,6 +21,9 @@ namespace request {
         // Common
         Command cmd;
         UsbRomBoot() : cmd(USB_ROM_BOOT) {}
+
+        // Data
+        bool keepUsbBootAfterAppRestart = false;
     };
     struct BootApplication {
         // Common


### PR DESCRIPTION
- UpdateFlash: add a `BOOT_HEADER` storage area, that for now overlaps with `BOOTLOADER`, but in the future we should make it separate. Used for now to flash an USB boot header (that would overwrite the bootloader).
- UsbRomBoot: add a flag `keepUsbBootAfterAppRestart`, for the USB-booted Gen2 app to not switch again to bootloader. Mainly to be used with a booloader request to switch to USB boot mode.